### PR TITLE
Refactor pinging

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,12 +12,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "arrayvec"
-version = "0.7.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
-
-[[package]]
 name = "async-channel"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -138,15 +132,6 @@ checksum = "534c5cf6194dfab3db3242765c03bbe257cf92f22b38f6bc0c58d59108a820ba"
 dependencies = [
  "libc",
  "windows-sys",
-]
-
-[[package]]
-name = "etherparse"
-version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8d8a704b617484e9d867a0423cd45f7577f008c4068e2e33378f8d3860a6d73"
-dependencies = [
- "arrayvec",
 ]
 
 [[package]]
@@ -982,7 +967,6 @@ dependencies = [
  "async-channel",
  "env_filter",
  "env_logger",
- "etherparse",
  "futures-util",
  "gettext-rs",
  "glib",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,6 @@ adw = { package = "libadwaita", version = "0.7.0", features = ["v1_6"] }
 async-channel = "2.3.1"
 env_filter = "0.1.0"
 env_logger = { version = "0.11.5", default-features = false }
-etherparse = "0.16.0"
 futures-util = { version = "0.3.31", default-features = false }
 gettext-rs = { version = "0.7.2", features = ["gettext-system"] }
 glib = { version = "0.20.4", features = ["log"] }

--- a/src/net.rs
+++ b/src/net.rs
@@ -17,7 +17,6 @@ use std::os::fd::{AsRawFd, OwnedFd};
 use std::rc::Rc;
 use std::time::Duration;
 
-use etherparse::{IcmpEchoHeader, Icmpv4Slice, Icmpv4Type, Icmpv6Slice, Icmpv6Type};
 use futures_util::stream;
 use futures_util::stream::FuturesUnordered;
 use futures_util::{future, select_biased, FutureExt, Stream, StreamExt, TryFutureExt};
@@ -83,19 +82,11 @@ fn to_rust(address: InetAddress) -> IpAddr {
     }
 }
 
-/// A reply to a single ping.
-#[derive(Debug)]
-pub enum PingReply {
-    /// A correct ICMP echo reply.
-    EchoReply,
-    /// Another response for an ICMP v4 echo request.
-    OtherV4(Icmpv4Type),
-    /// Another response for an ICMP v6 echo request.
-    OtherV6(Icmpv6Type),
-}
-
 /// Send a single ping to `ip_address`.
-async fn ping(ip_address: IpAddr) -> Result<PingReply, Box<dyn Error>> {
+///
+/// Return an error if pinging `ip_address` failed, or if we received a non-reply
+/// response.
+async fn ping(ip_address: IpAddr) -> Result<(), Box<dyn Error>> {
     log::trace!("Sending ICMP echo request to {ip_address}");
     let (domain, protocol) = match ip_address {
         IpAddr::V4(_) => (Domain::IPV4, Protocol::ICMPV4),
@@ -117,24 +108,36 @@ async fn ping(ip_address: IpAddr) -> Result<PingReply, Box<dyn Error>> {
     let condition =
         socket.create_source_future(IOCondition::IN, Cancellable::NONE, glib::Priority::DEFAULT);
     let socket_address: gio::InetSocketAddress = SocketAddr::new(ip_address, 0).into();
-    let header = IcmpEchoHeader { id: 42, seq: 23 };
-    let payload = b"turnon-ping turnon-ping turnon-ping turnon-ping";
-    let mut packet = match ip_address {
-        IpAddr::V4(_) => {
-            let echo = etherparse::Icmpv4Type::EchoRequest(header);
-            let header = etherparse::Icmpv4Header::with_checksum(echo, payload);
-            header.to_bytes().to_vec()
-        }
-        IpAddr::V6(_) => {
-            let echo = etherparse::Icmpv6Type::EchoRequest(header);
-            let header =
-                etherparse::Icmpv6Header::with_checksum(echo, [0; 16], [0; 16], payload).unwrap();
-            header.to_bytes().to_vec()
-        }
+    // An echo reply for ICMPv4 and ICMPv6 respectively.
+    let r#type = match ip_address {
+        IpAddr::V4(_) => 8u8,
+        IpAddr::V6(_) => 128u8,
     };
-    packet.extend_from_slice(payload);
-    let bytes_written = socket.send_to(Some(&socket_address), &packet, Cancellable::NONE)?;
-    assert!(bytes_written == packet.len());
+    // Our ICMP packet.  ICMPv4 and ICMPv6 have the same layout, so we can use the
+    // same packet for both.
+    //
+    // Documentation around unprivileged ICMP is somewhat sparse in Linux land, but
+    // it seems that the kernel handles the checksum and the identifier for us,
+    // so we can statically assemble the packet.
+    let echo_request = [
+        r#type, // Type
+        0,      // code,
+        0, 0, // Checksum
+        0, 0, // Identifier
+        0, 0, // Sequence number
+        b't', b'u', b'r', b'n', b'o', b'n', b'-', b'p', b'i', b'n', b'g', b'\n', // line 1
+        b't', b'u', b'r', b'n', b'o', b'n', b'-', b'p', b'i', b'n', b'g', b'\n', // line 2
+        b't', b'u', b'r', b'n', b'o', b'n', b'-', b'p', b'i', b'n', b'g', b'\n', // line 3
+        b't', b'u', b'r', b'n', b'o', b'n', b'-', b'p', b'i', b'n', b'g', b'\n', // line 4
+    ];
+    let bytes_written = socket.send_to(Some(&socket_address), echo_request, Cancellable::NONE)?;
+    if bytes_written != echo_request.len() {
+        return Err(std::io::Error::new(
+            ErrorKind::BrokenPipe,
+            format!("Failed to write full ICMP echo request to {ip_address} to socket"),
+        )
+        .into());
+    }
     if condition.await != glib::IOCondition::IN {
         socket.close().ok();
         return Err(std::io::Error::new(
@@ -144,18 +147,30 @@ async fn ping(ip_address: IpAddr) -> Result<PingReply, Box<dyn Error>> {
         .into());
     }
 
-    let mut buffer = [0; 128];
-    let (bytes_received, _) = socket.receive_from(&mut buffer, Cancellable::NONE)?;
+    // We expect a response of the same size as the echo request: The response
+    // header has the same size, and the payload is mirrored back.
+    let mut response = [0; 56];
+    // Sanity check in case we got the array length wrong!
+    assert!(response.len() == echo_request.len());
+    let (bytes_received, _) = socket.receive_from(&mut response, Cancellable::NONE)?;
     socket.close().ok();
+    if bytes_received != response.len() {
+        return Err(std::io::Error::new(
+            ErrorKind::BrokenPipe,
+            format!("Failed to read full ICMP echo reply from {ip_address} from socket"),
+        )
+        .into());
+    }
+
+    // Check that we received an echo reply.
     match ip_address {
-        IpAddr::V4(_) => match Icmpv4Slice::from_slice(&buffer[..bytes_received])?.icmp_type() {
-            Icmpv4Type::EchoReply(_) => Ok(PingReply::EchoReply),
-            other => Ok(PingReply::OtherV4(other)),
-        },
-        IpAddr::V6(_) => match Icmpv6Slice::from_slice(&buffer[..bytes_received])?.icmp_type() {
-            Icmpv6Type::EchoReply(_) => Ok(PingReply::EchoReply),
-            other => Ok(PingReply::OtherV6(other)),
-        },
+        IpAddr::V4(_) if response[0] == 0 => Ok(()),
+        IpAddr::V6(_) if response[0] == 129 => Ok(()),
+        _ => Err(std::io::Error::new(
+            ErrorKind::InvalidData,
+            format!("Received unexpected response of type {}", response[0]),
+        )
+        .into()),
     }
 }
 
@@ -217,17 +232,9 @@ pub fn monitor(target: Target, interval: Duration) -> impl Stream<Item = bool> {
                     })
                     // Filter out all address which we can't ping or which don't reply
                     .filter_map(|(ip_address, result)| match result {
-                        Ok(PingReply::EchoReply) => {
+                        Ok(_) => {
                             log::trace!("{ip_address} replied to ping");
                             future::ready(Some(ip_address))
-                        }
-                        Ok(PingReply::OtherV4(other)) => {
-                            log::trace!("{ip_address} did not reply: {other:?}");
-                            future::ready(None)
-                        }
-                        Ok(PingReply::OtherV6(other)) => {
-                            log::trace!("{ip_address} did not reply: {other:?}");
-                            future::ready(None)
                         }
                         Err(error) => {
                             log::trace!("Failed to ping {ip_address}: {error}");

--- a/src/widgets/application_window.rs
+++ b/src/widgets/application_window.rs
@@ -165,8 +165,11 @@ mod imp {
                 row,
                 #[upgrade_or]
                 futures_util::future::err(()),
-                move |is_online| {
-                    row.set_is_device_online(is_online);
+                move |result| {
+                    if let Err(error) = &result {
+                        log::trace!("Device {} not reachable: {error}", row.device().label());
+                    }
+                    row.set_is_device_online(result.is_ok());
                     futures_util::future::ok(())
                 }
             )));

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -38,10 +38,6 @@ criteria = "safe-to-run"
 version = "2.5.0"
 criteria = "safe-to-run"
 
-[[exemptions.etherparse]]
-version = "0.16.0"
-criteria = "safe-to-run"
-
 [[exemptions.event-listener]]
 version = "5.3.1"
 criteria = "safe-to-run"

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -378,15 +378,6 @@ user-id = 64539
 user-login = "kennykerr"
 user-name = "Kenny Kerr"
 
-[[audits.bytecode-alliance.audits.arrayvec]]
-who = "Nick Fitzgerald <fitzgen@gmail.com>"
-criteria = "safe-to-deploy"
-version = "0.7.2"
-notes = """
-Well documented invariants, good assertions for those invariants in unsafe code,
-and tested with MIRI to boot. LGTM.
-"""
-
 [[audits.bytecode-alliance.audits.memoffset]]
 who = "Alex Crichton <alex@alexcrichton.com>"
 criteria = "safe-to-deploy"
@@ -1107,13 +1098,6 @@ who = "Hung-Hsien Chen <hunghsienchen@chromium.org>"
 criteria = "safe-to-run"
 version = "0.6.18"
 aggregated-from = "https://chromium.googlesource.com/chromiumos/third_party/rust_crates/+/refs/heads/main/cargo-vet/audits.toml?format=TEXT"
-
-[[audits.mozilla.audits.arrayvec]]
-who = "Alex Franchuk <afranchuk@mozilla.com>"
-criteria = "safe-to-deploy"
-delta = "0.7.2 -> 0.7.6"
-notes = "Manually verified new unsafe pointer arithmetic."
-aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
 
 [[audits.mozilla.audits.crossbeam-utils]]
 who = "Jan-Erik Rediger <jrediger@mozilla.com>"


### PR DESCRIPTION
Drop huge and unsafe etherparse dependency and instead assemble ICMP packets manually.

Unify error handling on top of glib::Error.

Set and verify ICMP sequence numbers.