### PR TITLE
Drop gettext-rs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -36,12 +36,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
 
 [[package]]
-name = "block"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d8c1fef690941d3e7788d328517591fecc684c084084702d6ff1641e993699a"
-
-[[package]]
 name = "cairo-rs"
 version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -62,15 +56,6 @@ dependencies = [
  "glib-sys",
  "libc",
  "system-deps",
-]
-
-[[package]]
-name = "cc"
-version = "1.1.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2e7962b54006dcfcc61cb72735f4d89bb97061dd6a7ed882ec6b8ee53714c6f"
-dependencies = [
- "shlex",
 ]
 
 [[package]]
@@ -283,26 +268,6 @@ dependencies = [
  "pango-sys",
  "pkg-config",
  "system-deps",
-]
-
-[[package]]
-name = "gettext-rs"
-version = "0.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a44e92f7dc08430aca7ed55de161253a22276dfd69c5526e5c5e95d1f7cf338a"
-dependencies = [
- "gettext-sys",
- "locale_config",
-]
-
-[[package]]
-name = "gettext-sys"
-version = "0.22.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb45773f5b8945f12aecd04558f545964f943dacda1b1155b3d738f5469ef661"
-dependencies = [
- "cc",
- "temp-dir",
 ]
 
 [[package]]
@@ -541,12 +506,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
 
 [[package]]
-name = "lazy_static"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
-
-[[package]]
 name = "libadwaita"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -590,19 +549,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89"
 
 [[package]]
-name = "locale_config"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08d2c35b16f4483f6c26f0e4e9550717a2f6575bcd6f12a53ff0c490a94a6934"
-dependencies = [
- "lazy_static",
- "objc",
- "objc-foundation",
- "regex",
- "winapi",
-]
-
-[[package]]
 name = "log"
 version = "0.4.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -618,15 +564,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baee0bbc17ce759db233beb01648088061bf678383130602a298e6998eedb2d8"
 
 [[package]]
-name = "malloc_buf"
-version = "0.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62bb907fe88d54d8d9ce32a3cceab4218ed2f6b7d35617cafe9adf84e43919cb"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "memchr"
 version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -639,35 +576,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
 dependencies = [
  "autocfg",
-]
-
-[[package]]
-name = "objc"
-version = "0.2.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "915b1b472bc21c53464d6c8461c9d3af805ba1ef837e1cac254428f4a77177b1"
-dependencies = [
- "malloc_buf",
-]
-
-[[package]]
-name = "objc-foundation"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1add1b659e36c9607c7aab864a76c7a4c2760cd0cd2e120f3fb8b952c7e22bf9"
-dependencies = [
- "block",
- "objc",
- "objc_id",
-]
-
-[[package]]
-name = "objc_id"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c92d4ddb4bd7b50d730c215ff871754d0da6b2178849f8a2a2ab69712d0c073b"
-dependencies = [
- "objc",
 ]
 
 [[package]]
@@ -850,12 +758,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "shlex"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
-
-[[package]]
 name = "slab"
 version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -921,12 +823,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
 
 [[package]]
-name = "temp-dir"
-version = "0.1.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc1ee6eef34f12f765cb94725905c6312b6610ab2b0940889cfe58dae7bc3c72"
-
-[[package]]
 name = "toml"
 version = "0.8.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -968,7 +864,6 @@ dependencies = [
  "env_filter",
  "env_logger",
  "futures-util",
- "gettext-rs",
  "glib",
  "glib-build-tools",
  "glob",
@@ -999,28 +894,6 @@ name = "version-compare"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "852e951cb7832cb45cb1169900d19760cfa39b82bc0ea9c0e5a14ae88411c98b"
-
-[[package]]
-name = "winapi"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
-dependencies = [
- "winapi-i686-pc-windows-gnu",
- "winapi-x86_64-pc-windows-gnu",
-]
-
-[[package]]
-name = "winapi-i686-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
-
-[[package]]
-name = "winapi-x86_64-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-sys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,6 @@ async-channel = "2.3.1"
 env_filter = "0.1.0"
 env_logger = { version = "0.11.5", default-features = false }
 futures-util = { version = "0.3.31", default-features = false }
-gettext-rs = { version = "0.7.2", features = ["gettext-system"] }
 glib = { version = "0.20.4", features = ["log"] }
 gtk = { package = "gtk4", version = "0.9.2", features = ["gnome_47"] }
 log = "0.4.22"

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,8 @@ pot:
 		-name '*.metainfo.xml.in' \
 		-or -name '*.blp' ')' | sort > po/POTFILES.in
 	xgettext $(XGETTEXT_METADATA) --files-from=po/POTFILES.in \
-		--add-comments --keyword=_ --keyword=C_:1c,2 \
+		--add-comments \
+		--keyword=_ --keyword=C_:1c,2 --keyword=dpgettext2:2c,3 \
 		--sort-by-file --from-code=UTF-8 --output=po/de.swsnr.turnon.pot
 
 .PHONY: messages

--- a/flatpak/cargo-sources.json
+++ b/flatpak/cargo-sources.json
@@ -54,19 +54,6 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/block/block-0.1.6.crate",
-        "sha256": "0d8c1fef690941d3e7788d328517591fecc684c084084702d6ff1641e993699a",
-        "dest": "cargo/vendor/block-0.1.6"
-    },
-    {
-        "type": "inline",
-        "contents": "{\"package\": \"0d8c1fef690941d3e7788d328517591fecc684c084084702d6ff1641e993699a\", \"files\": {}}",
-        "dest": "cargo/vendor/block-0.1.6",
-        "dest-filename": ".cargo-checksum.json"
-    },
-    {
-        "type": "archive",
-        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/cairo-rs/cairo-rs-0.20.1.crate",
         "sha256": "e8a0ea147c94108c9613235388f540e4d14c327f7081c9e471fc8ee8a2533e69",
         "dest": "cargo/vendor/cairo-rs-0.20.1"
@@ -88,19 +75,6 @@
         "type": "inline",
         "contents": "{\"package\": \"428290f914b9b86089f60f5d8a9f6e440508e1bcff23b25afd51502b0a2da88f\", \"files\": {}}",
         "dest": "cargo/vendor/cairo-sys-rs-0.20.0",
-        "dest-filename": ".cargo-checksum.json"
-    },
-    {
-        "type": "archive",
-        "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/cc/cc-1.1.31.crate",
-        "sha256": "c2e7962b54006dcfcc61cb72735f4d89bb97061dd6a7ed882ec6b8ee53714c6f",
-        "dest": "cargo/vendor/cc-1.1.31"
-    },
-    {
-        "type": "inline",
-        "contents": "{\"package\": \"c2e7962b54006dcfcc61cb72735f4d89bb97061dd6a7ed882ec6b8ee53714c6f\", \"files\": {}}",
-        "dest": "cargo/vendor/cc-1.1.31",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -379,32 +353,6 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/gettext-rs/gettext-rs-0.7.2.crate",
-        "sha256": "a44e92f7dc08430aca7ed55de161253a22276dfd69c5526e5c5e95d1f7cf338a",
-        "dest": "cargo/vendor/gettext-rs-0.7.2"
-    },
-    {
-        "type": "inline",
-        "contents": "{\"package\": \"a44e92f7dc08430aca7ed55de161253a22276dfd69c5526e5c5e95d1f7cf338a\", \"files\": {}}",
-        "dest": "cargo/vendor/gettext-rs-0.7.2",
-        "dest-filename": ".cargo-checksum.json"
-    },
-    {
-        "type": "archive",
-        "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/gettext-sys/gettext-sys-0.22.5.crate",
-        "sha256": "bb45773f5b8945f12aecd04558f545964f943dacda1b1155b3d738f5469ef661",
-        "dest": "cargo/vendor/gettext-sys-0.22.5"
-    },
-    {
-        "type": "inline",
-        "contents": "{\"package\": \"bb45773f5b8945f12aecd04558f545964f943dacda1b1155b3d738f5469ef661\", \"files\": {}}",
-        "dest": "cargo/vendor/gettext-sys-0.22.5",
-        "dest-filename": ".cargo-checksum.json"
-    },
-    {
-        "type": "archive",
-        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/gio/gio-0.20.1.crate",
         "sha256": "dcacaa37401cad0a95aadd266bc39c72a131d454fc012f6dfd217f891d76cc52",
         "dest": "cargo/vendor/gio-0.20.1"
@@ -652,19 +600,6 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/lazy_static/lazy_static-1.5.0.crate",
-        "sha256": "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe",
-        "dest": "cargo/vendor/lazy_static-1.5.0"
-    },
-    {
-        "type": "inline",
-        "contents": "{\"package\": \"bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe\", \"files\": {}}",
-        "dest": "cargo/vendor/lazy_static-1.5.0",
-        "dest-filename": ".cargo-checksum.json"
-    },
-    {
-        "type": "archive",
-        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/libadwaita/libadwaita-0.7.0.crate",
         "sha256": "2ff9c222b5c783729de45185f07b2fec2d43a7f9c63961e777d3667e20443878",
         "dest": "cargo/vendor/libadwaita-0.7.0"
@@ -717,19 +652,6 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/locale_config/locale_config-0.3.0.crate",
-        "sha256": "08d2c35b16f4483f6c26f0e4e9550717a2f6575bcd6f12a53ff0c490a94a6934",
-        "dest": "cargo/vendor/locale_config-0.3.0"
-    },
-    {
-        "type": "inline",
-        "contents": "{\"package\": \"08d2c35b16f4483f6c26f0e4e9550717a2f6575bcd6f12a53ff0c490a94a6934\", \"files\": {}}",
-        "dest": "cargo/vendor/locale_config-0.3.0",
-        "dest-filename": ".cargo-checksum.json"
-    },
-    {
-        "type": "archive",
-        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/log/log-0.4.22.crate",
         "sha256": "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24",
         "dest": "cargo/vendor/log-0.4.22"
@@ -756,19 +678,6 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/malloc_buf/malloc_buf-0.0.6.crate",
-        "sha256": "62bb907fe88d54d8d9ce32a3cceab4218ed2f6b7d35617cafe9adf84e43919cb",
-        "dest": "cargo/vendor/malloc_buf-0.0.6"
-    },
-    {
-        "type": "inline",
-        "contents": "{\"package\": \"62bb907fe88d54d8d9ce32a3cceab4218ed2f6b7d35617cafe9adf84e43919cb\", \"files\": {}}",
-        "dest": "cargo/vendor/malloc_buf-0.0.6",
-        "dest-filename": ".cargo-checksum.json"
-    },
-    {
-        "type": "archive",
-        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/memchr/memchr-2.7.4.crate",
         "sha256": "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3",
         "dest": "cargo/vendor/memchr-2.7.4"
@@ -790,45 +699,6 @@
         "type": "inline",
         "contents": "{\"package\": \"488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a\", \"files\": {}}",
         "dest": "cargo/vendor/memoffset-0.9.1",
-        "dest-filename": ".cargo-checksum.json"
-    },
-    {
-        "type": "archive",
-        "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/objc/objc-0.2.7.crate",
-        "sha256": "915b1b472bc21c53464d6c8461c9d3af805ba1ef837e1cac254428f4a77177b1",
-        "dest": "cargo/vendor/objc-0.2.7"
-    },
-    {
-        "type": "inline",
-        "contents": "{\"package\": \"915b1b472bc21c53464d6c8461c9d3af805ba1ef837e1cac254428f4a77177b1\", \"files\": {}}",
-        "dest": "cargo/vendor/objc-0.2.7",
-        "dest-filename": ".cargo-checksum.json"
-    },
-    {
-        "type": "archive",
-        "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/objc-foundation/objc-foundation-0.1.1.crate",
-        "sha256": "1add1b659e36c9607c7aab864a76c7a4c2760cd0cd2e120f3fb8b952c7e22bf9",
-        "dest": "cargo/vendor/objc-foundation-0.1.1"
-    },
-    {
-        "type": "inline",
-        "contents": "{\"package\": \"1add1b659e36c9607c7aab864a76c7a4c2760cd0cd2e120f3fb8b952c7e22bf9\", \"files\": {}}",
-        "dest": "cargo/vendor/objc-foundation-0.1.1",
-        "dest-filename": ".cargo-checksum.json"
-    },
-    {
-        "type": "archive",
-        "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/objc_id/objc_id-0.1.1.crate",
-        "sha256": "c92d4ddb4bd7b50d730c215ff871754d0da6b2178849f8a2a2ab69712d0c073b",
-        "dest": "cargo/vendor/objc_id-0.1.1"
-    },
-    {
-        "type": "inline",
-        "contents": "{\"package\": \"c92d4ddb4bd7b50d730c215ff871754d0da6b2178849f8a2a2ab69712d0c073b\", \"files\": {}}",
-        "dest": "cargo/vendor/objc_id-0.1.1",
         "dest-filename": ".cargo-checksum.json"
     },
     {
@@ -1094,19 +964,6 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/shlex/shlex-1.3.0.crate",
-        "sha256": "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64",
-        "dest": "cargo/vendor/shlex-1.3.0"
-    },
-    {
-        "type": "inline",
-        "contents": "{\"package\": \"0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64\", \"files\": {}}",
-        "dest": "cargo/vendor/shlex-1.3.0",
-        "dest-filename": ".cargo-checksum.json"
-    },
-    {
-        "type": "archive",
-        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/slab/slab-0.4.9.crate",
         "sha256": "8f92a496fb766b417c996b9c5e57daf2f7ad3b0bebe1ccfca4856390e3d3bb67",
         "dest": "cargo/vendor/slab-0.4.9"
@@ -1198,19 +1055,6 @@
     {
         "type": "archive",
         "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/temp-dir/temp-dir-0.1.14.crate",
-        "sha256": "bc1ee6eef34f12f765cb94725905c6312b6610ab2b0940889cfe58dae7bc3c72",
-        "dest": "cargo/vendor/temp-dir-0.1.14"
-    },
-    {
-        "type": "inline",
-        "contents": "{\"package\": \"bc1ee6eef34f12f765cb94725905c6312b6610ab2b0940889cfe58dae7bc3c72\", \"files\": {}}",
-        "dest": "cargo/vendor/temp-dir-0.1.14",
-        "dest-filename": ".cargo-checksum.json"
-    },
-    {
-        "type": "archive",
-        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/toml/toml-0.8.19.crate",
         "sha256": "a1ed1f98e3fdc28d6d910e6737ae6ab1a93bf1985935a1193e68f93eeb68d24e",
         "dest": "cargo/vendor/toml-0.8.19"
@@ -1284,45 +1128,6 @@
         "type": "inline",
         "contents": "{\"package\": \"852e951cb7832cb45cb1169900d19760cfa39b82bc0ea9c0e5a14ae88411c98b\", \"files\": {}}",
         "dest": "cargo/vendor/version-compare-0.2.0",
-        "dest-filename": ".cargo-checksum.json"
-    },
-    {
-        "type": "archive",
-        "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/winapi/winapi-0.3.9.crate",
-        "sha256": "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419",
-        "dest": "cargo/vendor/winapi-0.3.9"
-    },
-    {
-        "type": "inline",
-        "contents": "{\"package\": \"5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419\", \"files\": {}}",
-        "dest": "cargo/vendor/winapi-0.3.9",
-        "dest-filename": ".cargo-checksum.json"
-    },
-    {
-        "type": "archive",
-        "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/winapi-i686-pc-windows-gnu/winapi-i686-pc-windows-gnu-0.4.0.crate",
-        "sha256": "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6",
-        "dest": "cargo/vendor/winapi-i686-pc-windows-gnu-0.4.0"
-    },
-    {
-        "type": "inline",
-        "contents": "{\"package\": \"ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6\", \"files\": {}}",
-        "dest": "cargo/vendor/winapi-i686-pc-windows-gnu-0.4.0",
-        "dest-filename": ".cargo-checksum.json"
-    },
-    {
-        "type": "archive",
-        "archive-type": "tar-gzip",
-        "url": "https://static.crates.io/crates/winapi-x86_64-pc-windows-gnu/winapi-x86_64-pc-windows-gnu-0.4.0.crate",
-        "sha256": "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f",
-        "dest": "cargo/vendor/winapi-x86_64-pc-windows-gnu-0.4.0"
-    },
-    {
-        "type": "inline",
-        "contents": "{\"package\": \"712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f\", \"files\": {}}",
-        "dest": "cargo/vendor/winapi-x86_64-pc-windows-gnu-0.4.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {

--- a/src/app.rs
+++ b/src/app.rs
@@ -73,8 +73,7 @@ mod imp {
 
     use adw::prelude::*;
     use adw::subclass::prelude::*;
-    use gettextrs::pgettext;
-    use glib::{OptionArg, OptionFlags};
+    use glib::{dpgettext2, OptionArg, OptionFlags};
     use gtk::gio::RegistrationId;
 
     use crate::model::{Device, Devices};
@@ -137,7 +136,7 @@ mod imp {
                 0.into(),
                 OptionFlags::NONE,
                 OptionArg::None,
-                &pgettext("option.add-device.description", "Add a new device"),
+                &dpgettext2(None, "option.add-device.description", "Add a new device"),
                 None,
             );
             app.add_main_option(
@@ -145,11 +144,16 @@ mod imp {
                 0.into(),
                 OptionFlags::NONE,
                 OptionArg::String,
-                &pgettext(
+                &dpgettext2(
+                    None,
                     "option.turn-on-device.description",
                     "Turn on a device by its label",
                 ),
-                Some(&pgettext("option.turn-on-device.arg.description", "LABEL")),
+                Some(&dpgettext2(
+                    None,
+                    "option.turn-on-device.arg.description",
+                    "LABEL",
+                )),
             )
         }
     }
@@ -246,7 +250,8 @@ mod imp {
                                         command_line
                                             .set_exit_status(glib::ExitCode::SUCCESS.value());
                                         command_line.print_literal(
-                                            &pgettext(
+                                            &dpgettext2(
+                                                None,
                                                 "option.turn-on-device.message",
                                                 "Sent magic packet to mac address %1 of device %2\n",
                                             )
@@ -256,7 +261,8 @@ mod imp {
                                     }
                                     Err(error) => {
                                         command_line.printerr_literal(
-                                            &pgettext(
+                                            &dpgettext2(
+                                                None,
                                                 "option.turn-on-device.error",
                                                 "Failed to turn on device %1: %2\n",
                                             )
@@ -274,7 +280,8 @@ mod imp {
                     }
                     None => {
                         command_line.printerr_literal(
-                            &pgettext(
+                            &dpgettext2(
+                                None,
                                 "option.turn-on-device.error",
                                 "No device found for label %s\n",
                             )

--- a/src/config.rs
+++ b/src/config.rs
@@ -6,8 +6,10 @@
 
 use std::path::PathBuf;
 
+use glib::{gstr, GStr};
+
 /// The app ID to use.
-pub static APP_ID: &str = "de.swsnr.turnon";
+pub static APP_ID: &GStr = gstr!("de.swsnr.turnon");
 
 /// Whether the app is running in flatpak.
 fn running_in_flatpak() -> bool {

--- a/src/gettext.rs
+++ b/src/gettext.rs
@@ -1,0 +1,69 @@
+// Copyright Sebastian Wiesner <sebastian@swsnr.de>
+
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+use std::ffi::{c_int, CString};
+use std::io::Result;
+use std::os::unix::ffi::OsStringExt;
+use std::path::PathBuf;
+
+use glib::GStr;
+
+pub fn bindtextdomain(domainname: &GStr, locale_dir: PathBuf) -> Result<()> {
+    let locale_dir = CString::new(locale_dir.into_os_string().into_vec()).unwrap();
+    let new_dir = unsafe { native::bindtextdomain(domainname.as_ptr(), locale_dir.as_ptr()) };
+    if new_dir.is_null() {
+        Err(std::io::Error::last_os_error())
+    } else {
+        Ok(())
+    }
+}
+
+pub fn textdomain(domainname: &GStr) -> Result<()> {
+    let new_domain = unsafe { native::textdomain(domainname.as_ptr()) };
+    if new_domain.is_null() {
+        Err(std::io::Error::last_os_error())
+    } else {
+        Ok(())
+    }
+}
+
+pub fn bind_textdomain_codeset(domainname: &GStr, codeset: &GStr) -> Result<()> {
+    let new_codeset =
+        unsafe { native::bind_textdomain_codeset(domainname.as_ptr(), codeset.as_ptr()) };
+    if new_codeset.is_null() {
+        Err(std::io::Error::last_os_error())
+    } else {
+        Ok(())
+    }
+}
+
+pub fn setlocale(category: c_int, locale: &GStr) -> Result<()> {
+    let current_locale = unsafe { native::setlocale(category, locale.as_ptr()) };
+    if current_locale.is_null() {
+        Err(std::io::Error::last_os_error())
+    } else {
+        Ok(())
+    }
+}
+
+pub const LC_ALL: c_int = 6;
+
+mod native {
+    use std::ffi::{c_char, c_int};
+
+    extern "C" {
+        pub fn bindtextdomain(domainname: *const c_char, dirname: *const c_char) -> *mut c_char;
+
+        pub fn textdomain(domain_name: *const c_char) -> *mut c_char;
+
+        pub fn bind_textdomain_codeset(
+            domainname: *const c_char,
+            codeset: *const c_char,
+        ) -> *mut c_char;
+
+        pub fn setlocale(category: c_int, locale: *const c_char) -> *mut c_char;
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,12 +8,15 @@
 
 use adw::prelude::*;
 use app::TurnOnApplication;
+use glib::gstr;
 use gtk::gio;
 use gtk::glib;
 
 mod app;
 mod config;
 mod dbus;
+mod gettext;
+
 mod model;
 mod net;
 mod searchprovider;
@@ -52,7 +55,7 @@ fn setup_logging() {
 fn main() -> glib::ExitCode {
     setup_logging();
 
-    use gettextrs::*;
+    use gettext::*;
     let locale_dir = config::locale_directory();
     log::debug!(
         "Initializing gettext with locale directory {}",
@@ -60,8 +63,8 @@ fn main() -> glib::ExitCode {
     );
     bindtextdomain(config::APP_ID, locale_dir).unwrap();
     textdomain(config::APP_ID).unwrap();
-    bind_textdomain_codeset(config::APP_ID, "UTF-8").unwrap();
-    setlocale(LocaleCategory::LcAll, "");
+    bind_textdomain_codeset(config::APP_ID, gstr!("UTF-8")).unwrap();
+    setlocale(LC_ALL, gstr!("")).unwrap();
 
     gio::resources_register_include!("turnon.gresource").unwrap();
     glib::set_application_name("Turn On");

--- a/src/searchprovider.rs
+++ b/src/searchprovider.rs
@@ -6,8 +6,7 @@
 
 //! Utilities for the search provider of Turn On.
 
-use gettextrs::pgettext;
-use glib::{ControlFlow, Variant, VariantDict};
+use glib::{dpgettext2, ControlFlow, Variant, VariantDict};
 use gtk::gio::{DBusMethodInvocation, Notification, NotificationPriority, RegistrationId};
 use gtk::prelude::*;
 
@@ -66,12 +65,14 @@ async fn activate_result(
             .wol()
             .await
             .inspect_err(|_| {
-                let notification = Notification::new(&pgettext(
+                let notification = Notification::new(&dpgettext2(
+                    None,
                     "search-provider.notification.title",
                     "Failed to send magic packet",
                 ));
                 notification.set_body(Some(
-                    &pgettext(
+                    &dpgettext2(
+                        None,
                         "search-provider.notification.body",
                         "Failed to send magic packet to mac address %1 of device %2.",
                     )
@@ -82,12 +83,14 @@ async fn activate_result(
                 app.send_notification(None, &notification);
             })
             .inspect(|_| {
-                let notification = Notification::new(&pgettext(
+                let notification = Notification::new(&dpgettext2(
+                    None,
                     "search-provider.notification.title",
                     "Sent magic packet",
                 ));
                 notification.set_body(Some(
-                    &pgettext(
+                    &dpgettext2(
+                        None,
                         "search-provider.notification.body",
                         "Sent magic packet to mac address %1 of device %2.",
                     )

--- a/src/widgets/application_window.rs
+++ b/src/widgets/application_window.rs
@@ -60,7 +60,7 @@ mod imp {
     use adw::subclass::prelude::*;
     use adw::{prelude::*, ToastOverlay};
     use futures_util::{stream, StreamExt, TryStreamExt};
-    use gettextrs::pgettext;
+    use glib::dpgettext2;
     use gtk::glib::subclass::InitializingObject;
     use gtk::glib::Properties;
     use gtk::{glib, CompositeTemplate};
@@ -104,7 +104,8 @@ mod imp {
             // Notify the user that we're about to send the magic packet to the target device
             let toast_sending = adw::Toast::builder()
                 .title(
-                    pgettext(
+                    dpgettext2(
+                        None,
                         "application-window.feedback.toast",
                         "Sending magic packet to device %s",
                     )
@@ -126,7 +127,8 @@ mod imp {
 
                             let toast = adw::Toast::builder()
                                 .title(
-                                    pgettext(
+                                    dpgettext2(
+                                        None,
                                         "application-window.feedback.toast",
                                         "Sent magic packet to device %s",
                                     )
@@ -140,7 +142,8 @@ mod imp {
                             toast_sending.inspect(|t| t.dismiss());
                             let toast = adw::Toast::builder()
                                 .title(
-                                    pgettext(
+                                    dpgettext2(
+                                        None,
                                         "application-window.feedback.toast",
                                         "Failed to send magic packet to device %s",
                                     )

--- a/supply-chain/audits.toml
+++ b/supply-chain/audits.toml
@@ -17,23 +17,6 @@ criteria = "safe-to-run"
 version = "0.3.6"
 notes = "Very simple crate which doesn't interact with the underlying system at all."
 
-[[audits.gettext-rs]]
-who = "Sebastian Wiesner <sebastian@swsnr.de>"
-criteria = "safe-to-run"
-version = "0.7.2"
-
-[[audits.gettext-sys]]
-who = "Sebastian Wiesner <sebastian@swsnr.de>"
-criteria = "safe-to-run"
-version = "0.22.5"
-notes = "build.rs looks okay; embedded gettext is an original upstream release file."
-
-[[audits.locale_config]]
-who = "Sebastian Wiesner <sebastian@swsnr.de>"
-criteria = "safe-to-run"
-version = "0.3.0"
-notes = "Only uses platform APIs to obtain locale information; no unsafe on unix."
-
 [[audits.macaddr]]
 who = "Sebastian Wiesner <sebastian@swsnr.de>"
 criteria = "safe-to-run"

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -26,16 +26,6 @@ criteria = "safe-to-run"
 version = "2.3.1"
 criteria = "safe-to-run"
 
-[[exemptions.block]]
-version = "0.1.6"
-criteria = "safe-to-run"
-suggest = false
-notes = "Only used by objc-foundation which in turn is only used on macOS by gettext-rs and thus does not apply to Turn On"
-
-[[exemptions.cc]]
-version = "1.1.31"
-criteria = "safe-to-run"
-
 [[exemptions.concurrent-queue]]
 version = "2.5.0"
 criteria = "safe-to-run"
@@ -47,24 +37,6 @@ criteria = "safe-to-run"
 [[exemptions.event-listener-strategy]]
 version = "0.5.2"
 criteria = "safe-to-run"
-
-[[exemptions.objc]]
-version = "0.2.7"
-criteria = "safe-to-run"
-suggest = false
-notes = "Only used by gettext-rs on macOS targets which does not apply to Turn On"
-
-[[exemptions.objc-foundation]]
-version = "0.1.1"
-criteria = "safe-to-run"
-suggest = false
-notes = "Only used by gettext-rs on macOS targets which does not apply to Turn On"
-
-[[exemptions.objc_id]]
-version = "0.1.1"
-criteria = "safe-to-run"
-suggest = false
-notes = "Only used by objc-foundation which in turn is only used on macOS by gettext-rs and thus does not apply to Turn On"
 
 [[exemptions.parking]]
 version = "2.2.1"
@@ -84,12 +56,6 @@ criteria = "safe-to-run"
 suggest = false
 notes = "Do not self-certify my own crate"
 
-[[exemptions.temp-dir]]
-version = "0.1.14"
-criteria = "safe-to-run"
-suggest = false
-notes = "Comes in via gettext-sys, perhaps we can get rid of it, see https://github.com/gettext-rs/gettext-rs/pull/130"
-
 [[exemptions.value-bag]]
 version = "1.9.0"
 criteria = "safe-to-run"
@@ -97,15 +63,3 @@ criteria = "safe-to-run"
 [[exemptions.version-compare]]
 version = "0.2.0"
 criteria = "safe-to-run"
-
-[[exemptions.winapi-i686-pc-windows-gnu]]
-version = "0.4.0"
-criteria = "safe-to-run"
-suggest = false
-notes = "winapi is only used by gettext-rs on Windows which does not apply to Turn On"
-
-[[exemptions.winapi-x86_64-pc-windows-gnu]]
-version = "0.4.0"
-criteria = "safe-to-run"
-suggest = false
-notes = "winapi is only used by gettext-rs on Windows which does not apply to Turn On"

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -560,27 +560,6 @@ Straightforward diff between 1.0.10 and 1.0.11 - only 3 commits:
 """
 aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
 
-[[audits.google.audits.lazy_static]]
-who = "Lukasz Anforowicz <lukasza@chromium.org>"
-criteria = "safe-to-deploy"
-version = "1.4.0"
-notes = '''
-I grepped for \"crypt\", \"cipher\", \"fs\", \"net\" - there were no hits.
-
-There are two places where `unsafe` is used.  Unsafe review notes can be found
-in https://crrev.com/c/5347418.
-
-This crate has been added to Chromium in https://crrev.com/c/3321895.
-'''
-aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
-
-[[audits.google.audits.lazy_static]]
-who = "Lukasz Anforowicz <lukasza@chromium.org>"
-criteria = "safe-to-deploy"
-delta = "1.4.0 -> 1.5.0"
-notes = "Unsafe review notes: https://crrev.com/c/5650836"
-aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
-
 [[audits.google.audits.log]]
 who = "danakj <danakj@chromium.org>"
 criteria = "safe-to-deploy"
@@ -991,18 +970,6 @@ criteria = "safe-to-run"
 version = "0.6.7"
 aggregated-from = "https://chromium.googlesource.com/chromiumos/third_party/rust_crates/+/refs/heads/main/cargo-vet/audits.toml?format=TEXT"
 
-[[audits.google.audits.shlex]]
-who = "George Burgess IV <gbiv@google.com>"
-criteria = "safe-to-run"
-version = "1.1.0"
-aggregated-from = "https://chromium.googlesource.com/chromiumos/third_party/rust_crates/+/refs/heads/main/cargo-vet/audits.toml?format=TEXT"
-
-[[audits.google.audits.shlex]]
-who = "Daniel Verkamp <dverkamp@chromium.org>"
-criteria = "safe-to-run"
-delta = "1.1.0 -> 1.3.0"
-aggregated-from = "https://chromium.googlesource.com/chromiumos/third_party/rust_crates/+/refs/heads/main/cargo-vet/audits.toml?format=TEXT"
-
 [[audits.google.audits.socket2]]
 who = "Vovo Yang <vovoy@google.com>"
 criteria = "safe-to-run"
@@ -1075,17 +1042,6 @@ delta = "1.0.12 -> 1.0.13"
 notes = "Lots of table updates, and tables are assumed correct with unsafe `.get_unchecked()`, so ub-risk-2 is appropriate"
 aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
 
-[[audits.google.audits.winapi]]
-who = "danakj@chromium.org"
-criteria = "safe-to-run"
-version = "0.3.9"
-notes = """
-Reviewed in https://crrev.com/c/5171063
-
-Previously reviewed during security review and the audit is grandparented in.
-"""
-aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
-
 [[audits.google.audits.winnow]]
 who = "Hung-Hsien Chen <hunghsienchen@chromium.org>"
 criteria = "safe-to-run"
@@ -1109,18 +1065,6 @@ aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-ch
 who = "Alex Franchuk <afranchuk@mozilla.com>"
 criteria = "safe-to-deploy"
 delta = "0.2.154 -> 0.2.158"
-aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
-
-[[audits.mozilla.audits.malloc_buf]]
-who = "Bobby Holley <bobbyholley@gmail.com>"
-criteria = "safe-to-deploy"
-version = "0.0.6"
-notes = """
-Very small crate for managing malloc-ed buffers, primarily for use in the objc crate.
-There is an edge-case condition that passes slice::from_raw_parts(0x1, 0) which I'm
-not entirely certain is technically sound, but in either case I am reasonably confident
-it's not exploitable.
-"""
 aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
 
 [[audits.mozilla.audits.pin-project-lite]]


### PR DESCRIPTION
Use glib::dpgettext2 instead of pgettext from gettextrs for actual messages.

Add extern declarations for required parts of the gettext textdomain API and write trivial safe wrappers around these, instead of using gettextrs for the textdomain setup.

This removes a few thousand lines of unaudited code from gettext-rs, gettext-sys, and its dependencies (such as locale-config) in favour of less than 100 lines of moderately unsafe code.

Fixes #17