### PR TITLE
Track existing devices for changes

### DIFF
--- a/resources/de.swsnr.turnon.metainfo.xml.in
+++ b/resources/de.swsnr.turnon.metainfo.xml.in
@@ -31,6 +31,7 @@
         <release version="next" date="9999-01-01">
             <description>
                 <p>Add Dutch translation, and update existing translations.</p>
+                <p>Correctly persist devices when a device was edited right after starting the application.</p>
             </description>
             <url>https://github.com/swsnr/turnon/releases/tag/next</url>
         </release>


### PR DESCRIPTION
When monitoring devices for changes in order to persist the model, we
not only need to monitor newly added devices, we also need to monitor
devices which already exist in the model right from the start.

Otherwise edits to devices won't be persisted unless a device is also
added or deleted at a later point.

Fixes #22