### PR TITLE
Reject socket addresses in host field

### DIFF
--- a/resources/de.swsnr.turnon.metainfo.xml.in
+++ b/resources/de.swsnr.turnon.metainfo.xml.in
@@ -33,7 +33,11 @@
         <release version="next" date="9999-01-01">
             <description>
                 <p>The dialog to add a new device now uses success and error styles for the validity indicators.</p>
+                <p>Refuse to add a new device if the host name contains a port which is not permitted at this place.</p>
             </description>
+            <issues>
+                <issue url="https://github.com/swsnr/turnon/issues/40">GH-40</issue>
+            </issues>
             <url>https://github.com/swsnr/turnon/releases/tag/next</url>
         </release>
         <release version="1.6.1" date="2024-11-29">

--- a/resources/ui/edit-device-dialog.blp
+++ b/resources/ui/edit-device-dialog.blp
@@ -59,11 +59,24 @@ template $EditDeviceDialog: Adw.Dialog {
             visible-child-name: bind template.host_indicator;
 
             Gtk.StackPage {
-              name: "empty";
+              name: "invalid-empty";
 
               child: Gtk.Image {
                 icon-name: "dialog-warning-symbolic";
                 tooltip-text: C_("edit-device-dialog.entry.host.feedback", "Please specify a target host to check availability");
+
+                styles [
+                  "error"
+                ]
+              };
+            }
+
+            Gtk.StackPage {
+              name: "invalid-socket-address";
+
+              child: Gtk.Image {
+                icon-name: "dialog-warning-symbolic";
+                tooltip-text: C_("edit-device-dialog.entry.socket-address.feedback", "This looks like a socket address with host and port, but a port is not permitted here!");
 
                 styles [
                   "error"

--- a/resources/ui/edit-device-dialog.ui
+++ b/resources/ui/edit-device-dialog.ui
@@ -64,11 +64,25 @@ corresponding .blp file and regenerate this file with blueprint-compiler.
                         <property name="visible-child-name" bind-source="EditDeviceDialog" bind-property="host_indicator" bind-flags="sync-create"/>
                         <child>
                           <object class="GtkStackPage">
-                            <property name="name">empty</property>
+                            <property name="name">invalid-empty</property>
                             <property name="child">
                               <object class="GtkImage">
                                 <property name="icon-name">dialog-warning-symbolic</property>
                                 <property name="tooltip-text" translatable="yes" context="edit-device-dialog.entry.host.feedback">Please specify a target host to check availability</property>
+                                <style>
+                                  <class name="error"/>
+                                </style>
+                              </object>
+                            </property>
+                          </object>
+                        </child>
+                        <child>
+                          <object class="GtkStackPage">
+                            <property name="name">invalid-socket-address</property>
+                            <property name="child">
+                              <object class="GtkImage">
+                                <property name="icon-name">dialog-warning-symbolic</property>
+                                <property name="tooltip-text" translatable="yes" context="edit-device-dialog.entry.socket-address.feedback">This looks like a socket address with host and port, but a port is not permitted here!</property>
                                 <style>
                                   <class name="error"/>
                                 </style>


### PR DESCRIPTION
Test if the host looks as if it's a hostname and a port, and reject this input, because ports are not allowed in the host name field.

Fixes #40