### PR TITLE
Add WakeableDevice interface

### DIFF
--- a/src/app/commandline.rs
+++ b/src/app/commandline.rs
@@ -15,7 +15,7 @@ use crate::app::TurnOnApplication;
 use crate::config::G_LOG_DOMAIN;
 use crate::net::PingDestination;
 
-use super::model::Device;
+use super::model::{Device, WakeableDeviceExt};
 
 async fn turn_on_device(
     command_line: &gio::ApplicationCommandLine,

--- a/src/app/model.rs
+++ b/src/app/model.rs
@@ -5,4 +5,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 mod device;
+mod wakeable_device;
+
 pub use device::Device;
+pub use wakeable_device::{WakeableDevice, WakeableDeviceExt};

--- a/src/app/model/device.rs
+++ b/src/app/model/device.rs
@@ -4,56 +4,23 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-use std::time::Duration;
-
-use futures_util::{select_biased, FutureExt};
-use gtk::gio::IOErrorEnum;
 use gtk::glib;
 
-use crate::config::G_LOG_DOMAIN;
-use crate::net::{wol, MacAddr6Boxed};
+use crate::net::MacAddr6Boxed;
+
+use super::WakeableDevice;
 
 glib::wrapper! {
-    pub struct Device(ObjectSubclass<imp::Device>);
+    pub struct Device(ObjectSubclass<imp::Device>) @implements WakeableDevice;
 }
 
 impl Device {
     pub fn new(label: &str, mac_address: MacAddr6Boxed, host: &str) -> Self {
         glib::Object::builder()
             .property("label", label)
-            .property("mac_address", mac_address)
+            .property("mac-address", mac_address)
             .property("host", host)
             .build()
-    }
-
-    /// Send the magic packet to this device.
-    pub async fn wol(&self) -> Result<(), glib::Error> {
-        let mac_address = self.mac_address();
-        glib::info!(
-            "Sending magic packet for mac address {mac_address} of device {}",
-            self.label()
-        );
-        let wol_timeout = Duration::from_secs(5);
-        let result = select_biased! {
-            result = wol(*mac_address).fuse() => result,
-            _ = glib::timeout_future(wol_timeout).fuse() => {
-                let message = &format!("Failed to send magic packet within {wol_timeout:#?}");
-                Err(glib::Error::new(IOErrorEnum::TimedOut, message))
-            }
-        };
-        result
-            .inspect(|_| {
-                glib::info!(
-                    "Sent magic packet to {mac_address} of device {}",
-                    self.label()
-                );
-            })
-            .inspect_err(|error| {
-                glib::warn!(
-                    "Failed to send magic packet to {mac_address} of device{}: {error}",
-                    self.label()
-                );
-            })
     }
 }
 
@@ -70,6 +37,7 @@ mod imp {
     use glib::subclass::prelude::*;
     use gtk::glib;
 
+    use crate::app::model::WakeableDevice;
     use crate::net::MacAddr6Boxed;
 
     #[derive(Debug, Default, glib::Properties)]
@@ -91,8 +59,28 @@ mod imp {
         const NAME: &'static str = "Device";
 
         type Type = super::Device;
+
+        type Interfaces = (WakeableDevice,);
     }
 
     #[glib::derived_properties]
     impl ObjectImpl for Device {}
+}
+
+#[cfg(test)]
+mod tests {
+    use glib::object::Cast;
+
+    use crate::app::model::{WakeableDevice, WakeableDeviceExt};
+
+    use super::Device;
+
+    #[test]
+    fn test_property_in_interface() {
+        let device = Device::default();
+        device.set_label("foobar");
+
+        let device_iface: WakeableDevice = device.upcast();
+        assert_eq!(device_iface.label(), "foobar");
+    }
 }

--- a/src/app/model/wakeable_device.rs
+++ b/src/app/model/wakeable_device.rs
@@ -1,0 +1,107 @@
+// Copyright Sebastian Wiesner <sebastian@swsnr.de>
+
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+use std::time::Duration;
+
+use futures_util::{select_biased, FutureExt};
+use glib::prelude::*;
+use glib::subclass::types::ObjectSubclass;
+use glib::{object::IsA, subclass::types::IsImplementable};
+use gtk::gio::IOErrorEnum;
+
+use crate::net::MacAddr6Boxed;
+use crate::{config::G_LOG_DOMAIN, net::wol};
+
+glib::wrapper! { pub struct WakeableDevice(ObjectInterface<imp::WakeableDevice>); }
+
+pub trait WakeableDeviceExt: IsA<WakeableDevice> {
+    /// The human-readable label for this device.
+    fn label(&self) -> String;
+
+    /// The MAC address of this device.
+    fn mac_address(&self) -> MacAddr6Boxed;
+
+    /// Send a magic packet to this device.
+    async fn wol(&self) -> Result<(), glib::Error> {
+        let mac_address = self.mac_address();
+        glib::info!(
+            "Sending magic packet for mac address {mac_address} of device {}",
+            self.label()
+        );
+        let wol_timeout = Duration::from_secs(5);
+        let result = select_biased! {
+            result = wol(*mac_address).fuse() => result,
+            _ = glib::timeout_future(wol_timeout).fuse() => {
+                let message = &format!("Failed to send magic packet within {wol_timeout:#?}");
+                Err(glib::Error::new(IOErrorEnum::TimedOut, message))
+            }
+        };
+        result
+            .inspect(|_| {
+                glib::info!(
+                    "Sent magic packet to {mac_address} of device {}",
+                    self.label()
+                );
+            })
+            .inspect_err(|error| {
+                glib::warn!(
+                    "Failed to send magic packet to {mac_address} of device{}: {error}",
+                    self.label()
+                );
+            })
+    }
+}
+
+impl<T: IsA<WakeableDevice>> WakeableDeviceExt for T {
+    fn mac_address(&self) -> MacAddr6Boxed {
+        self.property("mac-address")
+    }
+
+    fn label(&self) -> String {
+        self.property("label")
+    }
+}
+
+unsafe impl<T: ObjectSubclass> IsImplementable<T> for WakeableDevice {}
+
+mod imp {
+    use std::sync::OnceLock;
+
+    use glib::prelude::*;
+    use glib::subclass::prelude::*;
+    use glib::ParamSpecString;
+
+    use crate::net::MacAddr6Boxed;
+
+    #[repr(C)]
+    #[derive(Copy, Clone, Debug)]
+    pub struct WakeableDeviceClass(glib::gobject_ffi::GTypeInterface);
+
+    unsafe impl InterfaceStruct for WakeableDeviceClass {
+        type Type = WakeableDevice;
+    }
+
+    pub struct WakeableDevice;
+
+    #[glib::object_interface]
+    impl ObjectInterface for WakeableDevice {
+        const NAME: &'static str = "WakeableDevice";
+        type Interface = WakeableDeviceClass;
+
+        fn properties() -> &'static [glib::ParamSpec] {
+            static PROPERTIES: OnceLock<Vec<glib::ParamSpec>> = OnceLock::new();
+            PROPERTIES.get_or_init(|| {
+                vec![
+                    ParamSpecString::builder("label").read_only().build(),
+                    ParamSpecString::builder("host").read_only().build(),
+                    MacAddr6Boxed::param_spec_builder()("mac-address")
+                        .read_only()
+                        .build(),
+                ]
+            })
+        }
+    }
+}

--- a/src/app/searchprovider.rs
+++ b/src/app/searchprovider.rs
@@ -12,6 +12,7 @@ use gtk::gio::{
 };
 use gtk::prelude::*;
 
+use crate::app::model::WakeableDeviceExt;
 use crate::app::TurnOnApplication;
 use crate::config::G_LOG_DOMAIN;
 use crate::dbus::invocation::DBusMethodInvocationExt;

--- a/src/app/widgets/application_window.rs
+++ b/src/app/widgets/application_window.rs
@@ -69,7 +69,7 @@ mod imp {
     use gtk::glib::subclass::InitializingObject;
     use gtk::{glib, CompositeTemplate};
 
-    use crate::app::model::Device;
+    use crate::app::model::{Device, WakeableDeviceExt};
     use crate::config::G_LOG_DOMAIN;
     use crate::net;
 


### PR DESCRIPTION
Prepares for #45

## TODO

- [x] Add `WakeableDevice` interface and implement in in `RegisteredDevice`
- [ ] Use `WakeableDevice` in command line
- [ ] Use `WakeableDevice` for search provider
- [ ] Use `WakeableDevice` for main window
- [ ] Use `WakeableDevice` for model