### PR TITLE
Define additional shortcuts

### DIFF
--- a/resources/de.swsnr.turnon.metainfo.xml.in
+++ b/resources/de.swsnr.turnon.metainfo.xml.in
@@ -34,6 +34,7 @@
         <release version="next" date="9999-01-01">
             <description>
                 <p>Save and restore main window state.</p>
+                <p>Define additional shortcuts.</p>
                 <p>Update translations.</p>
             </description>
             <issues>

--- a/resources/gtk/help-overlay.blp
+++ b/resources/gtk/help-overlay.blp
@@ -18,12 +18,63 @@ Gtk.ShortcutsWindow help_overlay {
     section-name: "shortcuts";
 
     Gtk.ShortcutsGroup {
-      title: C_("shortcuts group", "General");
+      title: C_("shortcuts group", "Devices");
 
       Gtk.ShortcutsShortcut {
         title: C_("shortcut description", "Add a new device");
-        action-name: "win.add-device";
+        accelerator: "<Ctrl>N";
       }
+
+      Gtk.ShortcutsShortcut {
+        title: C_("shortcut description", "Toggle network scanning");
+        accelerator: "F5";
+      }
+    }
+
+    Gtk.ShortcutsGroup {
+      title: C_("shortcuts group", "Single device");
+
+      Gtk.ShortcutsShortcut {
+        title: C_("shortcut description", "Turn on device");
+        accelerator: "Return";
+      }
+
+      Gtk.ShortcutsShortcut {
+        title: C_("shortcut description", "Edit device");
+        accelerator: "<Alt>Return";
+      }
+
+      Gtk.ShortcutsShortcut {
+        title: C_("shortcut description", "Ask to delete device");
+        accelerator: "Delete";
+      }
+
+      Gtk.ShortcutsShortcut {
+        title: C_("shortcut description", "Immediately delete device without confirmation");
+        accelerator: "<Ctrl>Delete";
+      }
+    }
+
+    Gtk.ShortcutsGroup {
+      title: C_("shortcuts group", "Discovered device");
+
+      Gtk.ShortcutsShortcut {
+        title: C_("shortcut description", "Add as a new device");
+        accelerator: "<Ctrl>N";
+      }
+    }
+
+    Gtk.ShortcutsGroup {
+      title: C_("shortcuts group", "Edit device");
+
+      Gtk.ShortcutsShortcut {
+        title: C_("shortcut description", "Save device");
+        accelerator: "<Ctrl>S";
+      }
+    }
+
+    Gtk.ShortcutsGroup {
+      title: C_("shortcuts group", "General");
 
       Gtk.ShortcutsShortcut {
         title: C_("shortcut description", "Show shortcuts");

--- a/resources/gtk/help-overlay.ui
+++ b/resources/gtk/help-overlay.ui
@@ -13,13 +13,75 @@ corresponding .blp file and regenerate this file with blueprint-compiler.
         <property name="section-name">shortcuts</property>
         <child>
           <object class="GtkShortcutsGroup">
-            <property name="title" translatable="yes" context="shortcuts group">General</property>
+            <property name="title" translatable="yes" context="shortcuts group">Devices</property>
             <child>
               <object class="GtkShortcutsShortcut">
                 <property name="title" translatable="yes" context="shortcut description">Add a new device</property>
-                <property name="action-name">win.add-device</property>
+                <property name="accelerator">&lt;Ctrl&gt;N</property>
               </object>
             </child>
+            <child>
+              <object class="GtkShortcutsShortcut">
+                <property name="title" translatable="yes" context="shortcut description">Toggle network scanning</property>
+                <property name="accelerator">F5</property>
+              </object>
+            </child>
+          </object>
+        </child>
+        <child>
+          <object class="GtkShortcutsGroup">
+            <property name="title" translatable="yes" context="shortcuts group">Single device</property>
+            <child>
+              <object class="GtkShortcutsShortcut">
+                <property name="title" translatable="yes" context="shortcut description">Turn on device</property>
+                <property name="accelerator">Return</property>
+              </object>
+            </child>
+            <child>
+              <object class="GtkShortcutsShortcut">
+                <property name="title" translatable="yes" context="shortcut description">Edit device</property>
+                <property name="accelerator">&lt;Alt&gt;Return</property>
+              </object>
+            </child>
+            <child>
+              <object class="GtkShortcutsShortcut">
+                <property name="title" translatable="yes" context="shortcut description">Ask to delete device</property>
+                <property name="accelerator">Delete</property>
+              </object>
+            </child>
+            <child>
+              <object class="GtkShortcutsShortcut">
+                <property name="title" translatable="yes" context="shortcut description">Immediately delete device without confirmation</property>
+                <property name="accelerator">&lt;Ctrl&gt;Delete</property>
+              </object>
+            </child>
+          </object>
+        </child>
+        <child>
+          <object class="GtkShortcutsGroup">
+            <property name="title" translatable="yes" context="shortcuts group">Discovered device</property>
+            <child>
+              <object class="GtkShortcutsShortcut">
+                <property name="title" translatable="yes" context="shortcut description">Add as a new device</property>
+                <property name="accelerator">&lt;Ctrl&gt;N</property>
+              </object>
+            </child>
+          </object>
+        </child>
+        <child>
+          <object class="GtkShortcutsGroup">
+            <property name="title" translatable="yes" context="shortcuts group">Edit device</property>
+            <child>
+              <object class="GtkShortcutsShortcut">
+                <property name="title" translatable="yes" context="shortcut description">Save device</property>
+                <property name="accelerator">&lt;Ctrl&gt;S</property>
+              </object>
+            </child>
+          </object>
+        </child>
+        <child>
+          <object class="GtkShortcutsGroup">
+            <property name="title" translatable="yes" context="shortcuts group">General</property>
             <child>
               <object class="GtkShortcutsShortcut">
                 <property name="title" translatable="yes" context="shortcut description">Show shortcuts</property>

--- a/resources/ui/device-row.blp
+++ b/resources/ui/device-row.blp
@@ -64,37 +64,37 @@ template $DeviceRow: Adw.ActionRow {
         child: Gtk.Box {
           orientation: horizontal;
 
-          Gtk.Button {
+          Gtk.Button add {
             icon-name: "list-add-symbolic";
             tooltip-text: C_("device-row.action.row.add.tooltip", "Add this device");
             action-name: "row.add";
             valign: center;
-            visible: bind template.can-add;
+            visible: bind add.sensitive;
 
             styles [
               "flat"
             ]
           }
 
-          Gtk.Button {
+          Gtk.Button edit {
             icon-name: "document-edit-symbolic";
             tooltip-text: C_("device-row.action.row.edit.tooltip", "Edit this device");
             action-name: "row.edit";
             valign: center;
-            visible: bind template.can-edit;
+            visible: bind edit.sensitive;
 
             styles [
               "flat"
             ]
           }
 
-          Gtk.Button {
+          Gtk.Button delete {
             icon-name: "user-trash-symbolic";
             tooltip-text: C_("device-row.action.row.ask-delete.tooltip", "Delete this device?");
-            action-name: "row.ask_delete";
+            action-name: "row.ask-delete";
             margin-start: 6;
             valign: center;
-            visible: bind template.can-delete;
+            visible: bind delete.sensitive;
 
             styles [
               "flat"

--- a/resources/ui/device-row.ui
+++ b/resources/ui/device-row.ui
@@ -90,37 +90,37 @@ corresponding .blp file and regenerate this file with blueprint-compiler.
                   <object class="GtkBox">
                     <property name="orientation">0</property>
                     <child>
-                      <object class="GtkButton">
+                      <object class="GtkButton" id="add">
                         <property name="icon-name">list-add-symbolic</property>
                         <property name="tooltip-text" translatable="yes" context="device-row.action.row.add.tooltip">Add this device</property>
                         <property name="action-name">row.add</property>
                         <property name="valign">3</property>
-                        <property name="visible" bind-source="DeviceRow" bind-property="can-add" bind-flags="sync-create"/>
+                        <property name="visible" bind-source="add" bind-property="sensitive" bind-flags="sync-create"/>
                         <style>
                           <class name="flat"/>
                         </style>
                       </object>
                     </child>
                     <child>
-                      <object class="GtkButton">
+                      <object class="GtkButton" id="edit">
                         <property name="icon-name">document-edit-symbolic</property>
                         <property name="tooltip-text" translatable="yes" context="device-row.action.row.edit.tooltip">Edit this device</property>
                         <property name="action-name">row.edit</property>
                         <property name="valign">3</property>
-                        <property name="visible" bind-source="DeviceRow" bind-property="can-edit" bind-flags="sync-create"/>
+                        <property name="visible" bind-source="edit" bind-property="sensitive" bind-flags="sync-create"/>
                         <style>
                           <class name="flat"/>
                         </style>
                       </object>
                     </child>
                     <child>
-                      <object class="GtkButton">
+                      <object class="GtkButton" id="delete">
                         <property name="icon-name">user-trash-symbolic</property>
                         <property name="tooltip-text" translatable="yes" context="device-row.action.row.ask-delete.tooltip">Delete this device?</property>
-                        <property name="action-name">row.ask_delete</property>
+                        <property name="action-name">row.ask-delete</property>
                         <property name="margin-start">6</property>
                         <property name="valign">3</property>
-                        <property name="visible" bind-source="DeviceRow" bind-property="can-delete" bind-flags="sync-create"/>
+                        <property name="visible" bind-source="delete" bind-property="sensitive" bind-flags="sync-create"/>
                         <style>
                           <class name="flat"/>
                         </style>

--- a/src/app/widgets/edit_device_dialog.rs
+++ b/src/app/widgets/edit_device_dialog.rs
@@ -64,6 +64,7 @@ mod imp {
 
     use adw::prelude::*;
     use adw::subclass::prelude::*;
+    use gtk::gdk::{Key, ModifierType};
     use gtk::glib::subclass::{InitializingObject, Signal};
     use gtk::glib::Properties;
     use gtk::CompositeTemplate;
@@ -221,6 +222,8 @@ mod imp {
                     dialog.close();
                 }
             });
+
+            klass.add_binding_action(Key::S, ModifierType::CONTROL_MASK, "device.save");
         }
 
         fn instance_init(obj: &InitializingObject<Self>) {


### PR DESCRIPTION
Make Ctrl+N add a discovered device if focus is on a discovered device.

Make Del and Ctrl Del delete a device with and without confirmation
respectively.

Make Ctrl+S save inputs in the edit dialog.

Make Alt+Return edit the current device.