### PR TITLE
Install new resources in flatpak manifest

### DIFF
--- a/flatpak/de.swsnr.turnon.yaml
+++ b/flatpak/de.swsnr.turnon.yaml
@@ -34,7 +34,11 @@ modules:
       # Install binary, app icon, desktop file, and appstream metadata
       - install -Dm0755 target/release/turnon /app/bin/de.swsnr.turnon
       - install -Dm0644 -t /app/share/icons/hicolor/scalable/apps/ resources/icons/scalable/apps/de.swsnr.turnon.svg
+      - install -Dm0644 -t /app/share/icons/hicolor/symbolic/apps/ resources/icons/symbolic/apps/de.swsnr.turnon-symbolic.svg
       - install -Dm0644 -t /app/share/applications/ de.swsnr.turnon.desktop
       - install -Dm0644 -t /app/share/metainfo/ resources/de.swsnr.turnon.metainfo.xml
       - install -Dm0644 -t /app/share/dbus-1/services/ dbus-1/de.swsnr.turnon.service
       - install -Dm0644 -t /app/share/gnome-shell/search-providers/ de.swsnr.turnon.search-provider.ini
+      # Install settings and compile them
+      - install -Dm0644 -t /app/share/glib-2.0/schemas/ schemas/de.swsnr.turnon.gschema.xml
+      - glib-compile-schemas --strict /app/share/glib-2.0/schemas


### PR DESCRIPTION
Install the symbolic icon, and the settings schema.

- [ ] **Only merge after the automated flatpak update after the next release, before copying the flatpak manifest to flathub**.
