### PR TITLE
Fix gettext initialization

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -41,7 +41,6 @@
 
 use adw::prelude::*;
 use app::TurnOnApplication;
-use glib::gstr;
 use gtk::gio;
 use gtk::glib;
 
@@ -72,10 +71,9 @@ fn main() -> glib::ExitCode {
         "Initializing gettext with locale directory {}",
         locale_dir.display()
     );
-    gettext::bindtextdomain(config::APP_ID, locale_dir).unwrap();
-    gettext::textdomain(config::APP_ID).unwrap();
-    gettext::bind_textdomain_codeset(config::APP_ID, gstr!("UTF-8")).unwrap();
-    gettext::setlocale(gettext::LC_ALL, gstr!("")).unwrap();
+    if let Err(error) = gettext::init_gettext(config::APP_ID, locale_dir) {
+        glib::warn!("Failed to initialize gettext: {error}");
+    }
 
     gio::resources_register_include!("turnon.gresource").unwrap();
     glib::set_application_name("Turn On");


### PR DESCRIPTION
We must call setlocale first as gettext needs it.

We also ignore all errors now, since gettext errors aren't fatal; we'll
just fall back to untranslated strings in worst case.

And finally, let's juse libc for setlocale and LC_ALL; we already have
that dependency anyway, so let's not needlessly copy FFI definitions.

Closes GH-109